### PR TITLE
Api4com changes

### DIFF
--- a/docs/lwpCall.md
+++ b/docs/lwpCall.md
@@ -415,6 +415,21 @@ Returns:
 callId hassession progress established ended hold muted primary inTransfer
 direction terminating originating localIdentity remoteIdentity
 
+#### getCustomHeaders()
+
+List of custom headers sent, custom headers starting with X-
+
+Returns:
+
+The return is an Object with the properties key, value associated with each of the custom headers.
+
+```json
+{
+  "X-CustomHeader": "present",
+  "X-AnotherHeader": "anotherValue"
+}
+```
+
 ## Configuration
 
 | Name                  | Type     | Default | Description                                                                                                                                       |

--- a/src/lwpCall.js
+++ b/src/lwpCall.js
@@ -416,6 +416,23 @@ export default class {
     };
   }
 
+  getCustomHeaders() {
+    const session = this._getSession();
+    const request = session._request;
+    if (request && request.headers) {
+      return Object.keys(request.headers).reduce((customHeaders, headerName) => {
+        // make sure it's a custom header
+        if (headerName.startsWith('X-')) {
+          const headerValue = request.headers[headerName];
+          if (headerValue && Array.isArray(headerValue)) {
+            customHeaders[headerName] = headerValue.map(header => header.raw).toString();
+          }
+        }
+        return customHeaders;
+      }, {})
+    }
+  }
+
   /** Init functions */
 
   _initMediaElement(elementKind, deviceKind) {

--- a/src/lwpUserAgent.js
+++ b/src/lwpUserAgent.js
@@ -358,7 +358,7 @@ export default class extends lwpRenderer {
       /** TODO: nasty hack because Kazoo appears to be lower-casing the request user... */
       const config_user = this._userAgent._configuration.uri.user;
       const ruri_user = request.ruri.user;
-      if (config_user.toLowerCase() == ruri_user.toLowerCase()) {
+      if (config_user && ruri_user && config_user.toLowerCase() == ruri_user.toLowerCase()) {
         request.ruri.user = config_user;
       }
       return this._userAgent.__proto__.receiveRequest.call(


### PR DESCRIPTION
Avoid throwing an exception when we make an EVENT SIP OPTIONS request where the ruri_user variable is undefined, and with that when trying to execute the toLowerCase function it generates an exception.

src/lwpUserAgent.js
if (config_user && ruri_user && config_user.toLowerCase() == ruri_user.toLowerCase()) {
  request.ruri.user = config_user;
}

Add a new method in lwpCall to return the list of custom headers from a call as I needed to implement a logic where calls tagged with a certain header will be answered automatically.

```javascript
if (currentCall.isInProgress()) {
  const customHeaders = currentCall.getCustomHeaders()
  if (customHeaders && customHeaders['X-IntegratedCall'] === 'true') {
    return currentCall.answer()
  }
}
```